### PR TITLE
chore: Update to zkitter style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+.npmrc

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@r1oga/config",
+  "name": "@zkitter/config",
   "version": "1.0.0",
   "author": "r1oga",
   "license": "MIT",

--- a/packages/eslint/.eslintrc.yaml
+++ b/packages/eslint/.eslintrc.yaml
@@ -1,22 +1,28 @@
-plugins: ['@typescript-eslint', 'jest', 'sort']
+plugins: ['@typescript-eslint', 'sort']
 extends:
   [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:sort/recommended',
-    'standard-with-typescript',
     'prettier',
   ]
 parser: '@typescript-eslint/parser'
 parserOptions:
-  project: ['./tsconfig.json']
+  project: ['tsconfig.json']
 root: true
+settings:
+  import/resolver:
+    - typescript
 rules:
   '@typescript-eslint/ban-ts-comment': warn
   '@typescript-eslint/explicit-function-return-type': off
+  '@typescript-eslint/no-var-requires': warn
   '@typescript-eslint/return-await': off
+  '@typescript-eslint/no-this-alias': warn
   import/newline-after-import: warn
+  no-case-declarations: warn
   no-console: warn
+  no-empty:
+    - error
+    - allowEmptyCatch: true
   no-useless-constructor: warn
-env:
-  'jest/globals': true

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@r1oga/eslint-config",
-  "version": "1.1.5",
+  "name": "@zkitter/eslint-config",
+  "version": "1.0.0",
   "description": "Shared eslint configuration",
   "main": ".eslintrc.yaml",
   "files": [
@@ -28,12 +28,10 @@
     "@typescript-eslint/parser": "^5.46.1",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-config-standard-with-typescript": "^24.0.0",
+    "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^27.1.6",
     "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-sort": "^2.4.0"
-  },
-  "gitHead": "af64bc0dabc5e3fb6bbc6654b2d98288ff8e7ff9"
+  }
 }

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -18,8 +18,10 @@
   "author": "r1oga",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
   },
+  "repository": "https://github.com/zkitter/configs",
   "scripts": {
     "postinstall": "bash postinstall.sh"
   },

--- a/packages/eslint/postinstall.sh
+++ b/packages/eslint/postinstall.sh
@@ -2,7 +2,7 @@
 
 # see sharing eslint config & npm scoped modules https://eslint.org/docs/latest/developer-guide/shareable-configs#npm-scoped-modules
 if [[ ! -f  "$INIT_CWD/.eslintrc.yaml" ]];then
-  echo "extends: ['@r1oga']" > "$INIT_CWD/.eslintrc.yaml"
+  echo "extends: ['@zkitter']" > "$INIT_CWD/.eslintrc.yaml"
 fi
 
 cp -n .eslintignore "$INIT_CWD/.eslintignore"

--- a/packages/prettier/.prettierrc.yaml
+++ b/packages/prettier/.prettierrc.yaml
@@ -1,8 +1,11 @@
+arrowParens: avoid
 jsxSingleQuote: true
 parser: typescript
-semi: false
+printWidth: 100
+semi: true
 singleQuote: true
-trailingComma: all
+tabWidth: 2
+trailingComma: es5
 overrides:
   - files: '*.ts'
     options:

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -22,7 +22,8 @@
   "repository": "https://github.com/zkitter/configs",
   "scripts": {
     "build": "js-yaml .prettierrc.yaml > .prettierrc.json",
-    "postinstall": "bash postinstall.sh"
+    "postinstall": "bash postinstall.sh",
+    "prepare": "npm run build"
   },
   "peerDependencies": {
     "prettier": "^2.8.1"

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@r1oga/prettier-config",
-  "version": "1.1.8",
+  "name": "@zkitter/prettier-config",
+  "version": "1.0.0",
   "description": "Shared prettier configuration",
   "main": ".prettierrc.json",
   "files": [
@@ -25,7 +25,6 @@
   "peerDependencies": {
     "prettier": "^2.8.1"
   },
-  "gitHead": "af64bc0dabc5e3fb6bbc6654b2d98288ff8e7ff9",
   "devDependencies": {
     "js-yaml": "^4.1.0"
   }

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -16,8 +16,10 @@
   "author": "r1oga",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
   },
+  "repository": "https://github.com/zkitter/configs",
   "scripts": {
     "build": "js-yaml .prettierrc.yaml > .prettierrc.json",
     "postinstall": "bash postinstall.sh"

--- a/packages/prettier/postinstall.sh
+++ b/packages/prettier/postinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #echo "HERE"
 if [[ ! -f "$INIT_CWD/.prettierrc.yaml" ]];then
-  echo "'@r1oga/prettier-config'" > "$INIT_CWD/.prettierrc.yaml"
+  echo "'@zkitter/prettier-config'" > "$INIT_CWD/.prettierrc.yaml"
 fi
 
 cp -n .prettierignore "$INIT_CWD/.prettierignore"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,8 @@ importers:
       '@typescript-eslint/parser': ^5.46.1
       eslint: ^8.29.0
       eslint-config-prettier: ^8.5.0
-      eslint-config-standard-with-typescript: ^24.0.0
+      eslint-import-resolver-typescript: ^3.5.2
       eslint-plugin-import: ^2.26.0
-      eslint-plugin-jest: ^27.1.6
       eslint-plugin-n: ^15.6.0
       eslint-plugin-promise: ^6.1.1
       eslint-plugin-sort: ^2.4.0
@@ -25,9 +24,8 @@ importers:
       '@typescript-eslint/parser': 5.46.1_ha6vam6werchizxrnqvarmz2zu
       eslint: 8.29.0
       eslint-config-prettier: 8.5.0_eslint@8.29.0
-      eslint-config-standard-with-typescript: 24.0.0_f7skxvi3ubnnb5utlsc5vholvm
-      eslint-plugin-import: 2.26.0_z7hwuz3w5sq2sbhy7d4iqrnsvq
-      eslint-plugin-jest: 27.1.6_ly5exmwff5fio7d4gxjjnyhwtu
+      eslint-import-resolver-typescript: 3.5.2_lt3hqehuojhfcbzgzqfngbtmrq
+      eslint-plugin-import: 2.26.0_533pwayltjtlmylu2h73yxcye4
       eslint-plugin-n: 15.6.0_eslint@8.29.0
       eslint-plugin-promise: 6.1.1_eslint@8.29.0
       eslint-plugin-sort: 2.4.0_ha6vam6werchizxrnqvarmz2zu
@@ -1173,6 +1171,18 @@ packages:
       typescript: 4.9.4
     dev: true
 
+  /@pkgr/utils/2.3.1:
+    resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      is-glob: 4.0.3
+      open: 8.4.0
+      picocolors: 1.0.0
+      tiny-glob: 0.2.9
+      tslib: 2.4.1
+    dev: false
+
   /@tootallnate/once/2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -2067,7 +2077,6 @@ packages:
   /define-lazy-prop/2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
-    dev: true
 
   /define-properties/1.1.4:
     resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
@@ -2181,6 +2190,14 @@ packages:
       once: 1.4.0
     dev: true
 
+  /enhanced-resolve/5.12.0:
+    resolution: {integrity: sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      graceful-fs: 4.2.10
+      tapable: 2.2.1
+    dev: false
+
   /enquirer/2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
@@ -2279,42 +2296,6 @@ packages:
       eslint: 8.29.0
     dev: false
 
-  /eslint-config-standard-with-typescript/24.0.0_f7skxvi3ubnnb5utlsc5vholvm:
-    resolution: {integrity: sha512-vEnGXZ5aiR1enl9652iIP4nTpY3GPcNEwuhrsPbKO3Ce3D6T3yCqZdkUPk8nJetfdL/yO0DLsHg2d/l9iECIdg==}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^8.0.1
-      eslint-plugin-import: ^2.25.2
-      eslint-plugin-n: ^15.0.0
-      eslint-plugin-promise: ^6.0.0
-      typescript: '*'
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.46.1_imrg37k3svwu377c6q7gkarwmi
-      '@typescript-eslint/parser': 5.46.1_ha6vam6werchizxrnqvarmz2zu
-      eslint: 8.29.0
-      eslint-config-standard: 17.0.0_wnkmxhw54rcoqx42l6oqxte7qq
-      eslint-plugin-import: 2.26.0_z7hwuz3w5sq2sbhy7d4iqrnsvq
-      eslint-plugin-n: 15.6.0_eslint@8.29.0
-      eslint-plugin-promise: 6.1.1_eslint@8.29.0
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint-config-standard/17.0.0_wnkmxhw54rcoqx42l6oqxte7qq:
-    resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
-    peerDependencies:
-      eslint: ^8.0.1
-      eslint-plugin-import: ^2.25.2
-      eslint-plugin-n: ^15.0.0
-      eslint-plugin-promise: ^6.0.0
-    dependencies:
-      eslint: 8.29.0
-      eslint-plugin-import: 2.26.0_z7hwuz3w5sq2sbhy7d4iqrnsvq
-      eslint-plugin-n: 15.6.0_eslint@8.29.0
-      eslint-plugin-promise: 6.1.1_eslint@8.29.0
-    dev: false
-
   /eslint-import-resolver-node/0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
     dependencies:
@@ -2324,7 +2305,27 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.4_h4dlhne3g63bjzyi45ugdl2u4u:
+  /eslint-import-resolver-typescript/3.5.2_lt3hqehuojhfcbzgzqfngbtmrq:
+    resolution: {integrity: sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+    dependencies:
+      debug: 4.3.4
+      enhanced-resolve: 5.12.0
+      eslint: 8.29.0
+      eslint-plugin-import: 2.26.0_533pwayltjtlmylu2h73yxcye4
+      get-tsconfig: 4.2.0
+      globby: 13.1.3
+      is-core-module: 2.11.0
+      is-glob: 4.0.3
+      synckit: 0.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /eslint-module-utils/2.7.4_o2m23qb6cidzxlgoxlhvqp5c5y:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2349,6 +2350,7 @@ packages:
       debug: 3.2.7
       eslint: 8.29.0
       eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 3.5.2_lt3hqehuojhfcbzgzqfngbtmrq
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2364,7 +2366,7 @@ packages:
       regexpp: 3.2.0
     dev: false
 
-  /eslint-plugin-import/2.26.0_z7hwuz3w5sq2sbhy7d4iqrnsvq:
+  /eslint-plugin-import/2.26.0_533pwayltjtlmylu2h73yxcye4:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2381,7 +2383,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.29.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_h4dlhne3g63bjzyi45ugdl2u4u
+      eslint-module-utils: 2.7.4_o2m23qb6cidzxlgoxlhvqp5c5y
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -2393,27 +2395,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
-
-  /eslint-plugin-jest/27.1.6_ly5exmwff5fio7d4gxjjnyhwtu:
-    resolution: {integrity: sha512-XA7RFLSrlQF9IGtAmhddkUkBuICCTuryfOTfCSWcZHiHb69OilIH05oozH2XA6CEOtztnOd0vgXyvxZodkxGjg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.46.1_imrg37k3svwu377c6q7gkarwmi
-      '@typescript-eslint/utils': 5.46.1_ha6vam6werchizxrnqvarmz2zu
-      eslint: 8.29.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: false
 
   /eslint-plugin-n/15.6.0_eslint@8.29.0:
@@ -2857,6 +2838,10 @@ packages:
       get-intrinsic: 1.1.3
     dev: false
 
+  /get-tsconfig/4.2.0:
+    resolution: {integrity: sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==}
+    dev: false
+
   /git-raw-commits/2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
@@ -2957,6 +2942,10 @@ packages:
       type-fest: 0.20.2
     dev: false
 
+  /globalyzer/0.1.0:
+    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+    dev: false
+
   /globby/11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -2968,6 +2957,21 @@ packages:
       merge2: 1.4.1
       slash: 3.0.0
 
+  /globby/13.1.3:
+    resolution: {integrity: sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      dir-glob: 3.0.1
+      fast-glob: 3.2.12
+      ignore: 5.2.1
+      merge2: 1.4.1
+      slash: 4.0.0
+    dev: false
+
+  /globrex/0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: false
+
   /gopd/1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -2976,7 +2980,6 @@ packages:
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: true
 
   /grapheme-splitter/1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
@@ -3274,7 +3277,6 @@ packages:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
-    dev: true
 
   /is-extglob/2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3414,7 +3416,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-docker: 2.2.1
-    dev: true
 
   /isarray/1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -4226,7 +4227,6 @@ packages:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
-    dev: true
 
   /optionator/0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
@@ -4467,6 +4467,10 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: false
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -4856,6 +4860,11 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  /slash/4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
+    dev: false
+
   /smart-buffer/4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -5040,6 +5049,19 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  /synckit/0.8.4:
+    resolution: {integrity: sha512-Dn2ZkzMdSX827QbowGbU/4yjWuvNaCoScLLoMo/yKbu+P4GBR6cRGKZH27k6a9bRzdqcyd1DE96pQtQ6uNkmyw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    dependencies:
+      '@pkgr/utils': 2.3.1
+      tslib: 2.4.1
+    dev: false
+
+  /tapable/2.2.1:
+    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
+    engines: {node: '>=6'}
+    dev: false
+
   /tar-stream/2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -5094,6 +5116,13 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
+  /tiny-glob/0.2.9:
+    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
+    dependencies:
+      globalyzer: 0.1.0
+      globrex: 0.1.2
+    dev: false
+
   /tmp/0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -5142,7 +5171,6 @@ packages:
 
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-    dev: true
 
   /tsutils/3.21.0_typescript@4.9.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}


### PR DESCRIPTION
The idea is to have only 2 deps in zkitterd and zkitter ui:
- `@zkitter/eslint-config`
- `@zkitter/prettier-config`

It will install all the peer dependencies and the config files will just become

.prettierrc.yaml
```
'@zkitter/prettier-config'
```

```
extends: ['@zkitter']
```

To publish:
1. Create a GitHub personal access token with the following scopes: `delete:packages`, `repo`, `write:packages`
2. Login to github npm registry: `npm login --scope=@zkitter --registry=https://npm.pkg.github.com`
   username: github username
   password: github personal access token
3. `npm publish`